### PR TITLE
Add item-class setting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  x86_64-darwin-17
   x86_64-linux
 
 DEPENDENCIES

--- a/item.rb
+++ b/item.rb
@@ -1,0 +1,14 @@
+class Item
+  attr_accessor :genre, :author, :source, :label, :publish_date
+  attr_reader :id, :archived
+
+  def initialize(publish_date, archived)
+    @id = Random.rand(1..10_000)
+    @publish_date = publish_date
+    @archived = archived
+    @genre = nil
+    @author = nil
+    @source = nil
+    @label = nil
+  end
+end


### PR DESCRIPTION
Created Item class in a separate .rb file.
All Item class properties visible in the diagram are defined and set up in the constructor method.
Exception: properties for the 1-to-many relationships should NOT  set in the constructor method. Instead, they have a custom setter method created.