### PR TITLE
Override can_be_archived method in the Book class

### DIFF
--- a/classes/book.rb
+++ b/classes/book.rb
@@ -8,4 +8,10 @@ class Book < Item
     @publisher = publisher
     @cover_state = cover_state
   end
+
+  def can_be_archived?
+    return true if super || @cover_state == 'bad'
+
+    false
+  end
 end


### PR DESCRIPTION
This PR overrides the **can_be_archived** method in the **Book class** and implements the logic specified in the requirements. 