### PR TITLE
Add add_item method to Label class

### DIFF
--- a/classes/label.rb
+++ b/classes/label.rb
@@ -8,4 +8,11 @@ class Label
     @color = color
     @items = []
   end
+
+  def add_item(item)
+    return unless item.instance_of?(Item)
+
+    items << item
+    item.label = self
+  end
 end


### PR DESCRIPTION
This PR adds the **add_item** method to the **Label class**. It establishes the one-to-many relationship by setting the item's label property (i.e. _item.label_) to the current instance of Lable.
